### PR TITLE
removed chat from typings and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Official wrapper for nekos.life! Very small install size with no external depend
 | `why` | Get `text` of a question |
 | `catText`| Get `text` of a cat emoji |
 | `OwOify` | Get OwOified `text` of a string |
-| `chat` | Sends the text and replies with a `text` as a response |
 | `8Ball` | Sends the text and replies with a `text` as a response to the magic 8Ball and an image as well.|
 | `fact` | Gets the text and replies with a `text` that is a random fact |
 | `kemonomimi` | Get a URL of a kemonomimi image/gif |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Official wrapper for nekos.life! Very small install size with no external depend
 | `tits` | Gets a NSFW URL of an/a image/gif containing tits |
 | `girlSoloGif` | Gets a NSFW URL of a solo girl gif |
 | `girlSolo` | Gets a NSFW URL of a solo girl image |
-| `smallBoobs` | Gets a NSFW URL of an/a image/gif small boobs |
 | `pussyWankGif` | Gets a NSFW URL of a gif of pussy masterbation |
 | `pussyArt` | Gets a NSFW URL of an/a image/gif of pussy art |
 | `kemonomimi` | Gets a NSFW URL of an/a image/gif containing kemonomimi|

--- a/endpoints.json
+++ b/endpoints.json
@@ -17,7 +17,6 @@
     "tits": "/img/tits",
     "girlSoloGif": "/img/solog",
     "girlSolo": "/img/solo",
-    "smallBoobs": "/img/smallboobs",
     "pussyWankGif": "/img/pwankg",
     "pussyArt": "/img/pussy_jpg",
     "kemonomimi": "/img/lewdkemo",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,7 +20,6 @@ declare class NekoClient {
     why():Promise<NekoClient.NekoWhyResult>;
     catText():Promise<NekoClient.NekoCatResult>;
     OwOify(opts: NekoClient.NekoQueryParams):Promise<NekoClient.NekoOwOResult>;
-    chat(opts: NekoClient.NekoChatParams):Promise<NekoClient.NekoChatResults>;
     "8Ball"(opts: NekoClient.NekoQueryParams):Promise<NekoClient.NekoChatResults>;
     fact():Promise<NekoClient.NekoFactResult>;
     kemonomimi():Promise<NekoClient.NekoRequestResults>;
@@ -77,9 +76,6 @@ declare namespace NekoClient {
   //Help create options interface for the few functions that need it
   export interface NekoQueryParams {
     text: string;
-  }
-  export interface NekoChatParams extends NekoQueryParams {
-    owo?: boolean;
   }
   export interface NekoRequestResults {
     url: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,7 +44,6 @@ declare class NekoClient {
     tits():Promise<NekoClient.NekoRequestResults>;
     girlSoloGif():Promise<NekoClient.NekoRequestResults>;
     girlSolo():Promise<NekoClient.NekoRequestResults>;
-    smallBoobs():Promise<NekoClient.NekoRequestResults>;
     pussyWankGif():Promise<NekoClient.NekoRequestResults>;
     pussyArt():Promise<NekoClient.NekoRequestResults>;
     kemonomimi():Promise<NekoClient.NekoRequestResults>;


### PR DESCRIPTION
Seeing as the chat endpoint is deprecated now and as the method has been removed with the last pr, I removed it from the typings and readme.