### PR TITLE
Add endpoint types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -102,5 +102,5 @@ declare namespace NekoClient {
     fact: string; 
   }
   export type NekoSfwEndpoints = keyof NekoClient['sfw']
-  export type NekoNsfwEndpoints =keyof NekoClient['nsfw']
+  export type NekoNsfwEndpoints = keyof NekoClient['nsfw']
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -101,6 +101,6 @@ declare namespace NekoClient {
   export interface NekoFactResult {
     fact: string; 
   }
-  export type NekoSfwEndpoints = keyof NekoClient['sfw']
-  export type NekoNsfwEndpoints = keyof NekoClient['nsfw']
+  export type NekoSfwEndpoints = keyof NekoClient['sfw'];
+  export type NekoNsfwEndpoints = keyof NekoClient['nsfw'];
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -101,4 +101,6 @@ declare namespace NekoClient {
   export interface NekoFactResult {
     fact: string; 
   }
+  export type NekoSfwEndpoints = keyof NekoClient['sfw']
+  export type NekoNsfwEndpoints =keyof NekoClient['nsfw']
 }


### PR DESCRIPTION
This adds the new types NekoSfwEndpoints and NekoNsfwEndpoints. This is useful for having dynamic functions within typescript. 
Here is an example on why this is useful:
```ts
getHentai = async (type: NekoNsfwEndpoints) => {
    return (await nekos.nsfw[type]())?.url;
};
```
This helper function will get an image from any nsfw endpoint and only allow a valid Endpoint as parameter for type.
[Look at some TS related PR](https://app.gitkraken.com/glo/card/ba70e07ce88a46679a2e3f11976c9c3d)